### PR TITLE
Removing note regarding 2.10-only limitation for lift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ project/plugins/project/
 
 # Scala-IDE specific
 .scala_dependencies
+.idea/

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ where `[backend]` is one of the following JSON backends:
  - Jackson (`jackson`)
  - Jawn (`jawn`)
  - JSON4S (`json4s`)
- - Lift JSON (`lift` -- Scala 2.10 only)
+ - Lift JSON (`lift`)
  - Play JSON (`play`)
  - Spray (`spray`)
 
@@ -120,7 +120,7 @@ The following backends are available:
  - Jackson (`jackson`)
  - Jawn (`jawn`)
  - JSON4S (`json4s`)
- - Lift (`lift` -- Scala 2.10 only)
+ - Lift (`lift`)
  - Play (`play`)
  - Scala standard library JSON (`scalaJson`)
  - Spray (`spray`)


### PR DESCRIPTION
Assuming [rapture-json-lift PR#1](https://github.com/propensive/rapture-json-lift/pull/1) goes well...