### PR TITLE
UUID extractor and serialiser

### DIFF
--- a/src/extractors.scala
+++ b/src/extractors.scala
@@ -12,6 +12,8 @@
 \******************************************************************************************************************/
 package rapture.json
 
+import java.util.UUID
+
 import rapture.core._
 import rapture.data._
 
@@ -65,6 +67,10 @@ private[json] trait Extractors extends Extractors_1 {
   
   implicit val bigIntExtractor: Extractor[BigInt, Json] { type Throws = DataGetException } =
     bigDecimalExtractor.smap(_.toBigInt)
+
+  implicit val uuidExtractor: Extractor[UUID, Json] { type Throws = DataGetException } =
+    stringExtractor.smap { s : String => UUID.fromString(s) }
+
 }
 
 private[json] trait Extractors_1 {

--- a/src/serializers.scala
+++ b/src/serializers.scala
@@ -12,6 +12,8 @@
 \******************************************************************************************************************/
 package rapture.json
 
+import java.util.UUID
+
 import rapture.core._
 import rapture.data._
 
@@ -40,6 +42,9 @@ private[json] trait Serializers {
 
   implicit def stringSerializer(implicit ast: JsonAst): Serializer[String, Json] =
     BasicJsonSerializer(ast fromString _)
+
+  implicit def uuidSerializer(implicit ast :  JsonAst): Serializer[UUID, Json] =
+    BasicJsonSerializer { uuid : UUID => ast fromString uuid.toString }
 
   implicit def floatSerializer(implicit ast: JsonAst): Serializer[Float, Json] =
     BasicJsonSerializer(ast fromDouble _.toDouble)


### PR DESCRIPTION
Reason : It is often required to Serialize and Extract UUID Values from and to JSON encodings. It has been necessary (for this requestor at least) in the past to define custom Extractors and Serializers in such cases. 

Actions : These changes add this capability to the "Built-ins" by chaining the string serializers and extractors with the UUID to and from string methods. They follow the form of the other extractors/serialiser in the master branch.

HTH - Nige
 